### PR TITLE
[Demo Only] Github Action: Trigger pre-commit hooks

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,15 @@
+# Source: https://github.com/marketplace/actions/pre-commit
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
This commit demos how the pre-commit hooks worked via Github Action.

The action uses what is defined in [pre-commit YAML](https://github.com/dashk/autoevals/blob/main/.pre-commit-config.yaml), and runs those checks similar to when we do a pre-commit on the repo itself.

**GH Actions**
Running as a part of PR
![image](https://github.com/dashk/autoevals/assets/382644/ffd7079a-cd0e-4cfc-b687-ed1108ef1118)
Detailed Logging
![image](https://github.com/dashk/autoevals/assets/382644/a5fab206-6bfd-4a25-a492-2db280f675d0)

**Local**
![image](https://github.com/dashk/autoevals/assets/382644/9275e2da-5257-44b5-950c-30d453339287)
